### PR TITLE
Improvement of the computational speed in extended model fitting

### DIFF
--- a/cosipy/image_deconvolution/modelmap.py
+++ b/cosipy/image_deconvolution/modelmap.py
@@ -2,6 +2,9 @@ import astropy.units as u
 import numpy as np
 
 from histpy import Histogram, Axes, Axis, HealpixAxis
+import astropy.units as u
+
+from cosipy.threeml.custom_functions import get_integrated_spectral_model
 
 class ModelMap(Histogram):
 
@@ -10,19 +13,21 @@ class ModelMap(Histogram):
                  energy_edges,
                  scheme = 'ring',
                  coordsys = 'galactic',
+                 label_image = 'lb',
+                 label_energy = 'Ei'
                  ):
 
         if energy_edges.unit != u.keV:
             print("Warning (ModelMap): the unit of energy_edges is not keV!")
 
-        image_axis = HealpixAxis(nside = nside,
-                                 scheme = scheme,
-                                 coordsys = coordsys,
-                                 label = "lb")
+        self.image_axis = HealpixAxis(nside = nside,
+                                      scheme = scheme,
+                                      coordsys = coordsys,
+                                      label = label_image)
 
-        energy_axis = Axis(edges = energy_edges, label = "Ei", scale = "log")
+        self.energy_axis = Axis(edges = energy_edges, label = label_energy, scale = "log")
 
-        axes = Axes([image_axis, energy_axis])
+        axes = Axes([self.image_axis, self.energy_axis])
 
         super().__init__(axes, sparse = False, unit = 1 / u.s / u.cm**2 / u.sr) # unit might be specified in the input parameter.
 
@@ -33,3 +38,15 @@ class ModelMap(Histogram):
                 self[:,idx:idx+1] = value * self.unit
     #    elif algorithm_name == ... 
     #       ...
+
+    def set_values_from_extendedmodel(self, extendedmodel):
+
+        integrated_flux = get_integrated_spectral_model(spectrum = extendedmodel.spectrum.main.shape,
+                                                        eaxis = self.energy_axis)
+        
+        npix = self.image_axis.npix
+        coords = self.image_axis.pix2skycoord(np.arange(npix))
+
+        normalized_map = extendedmodel.spatial_shape(coords.l.deg, coords.b.deg) / u.sr
+
+        self[:] = np.tensordot(normalized_map, integrated_flux.contents, axes = 0) 

--- a/cosipy/threeml/COSILike.py
+++ b/cosipy/threeml/COSILike.py
@@ -2,7 +2,6 @@ from threeML import PluginPrototype
 from threeML.minimizer import minimization
 from threeML.config.config import threeML_config
 from threeML.exceptions.custom_exceptions import FitFailed
-from threeML import DiracDelta, Constant, Line, Quadratic, Cubic, Quartic, StepFunction, StepFunctionUpper, Cosine_Prior, Uniform_prior, PhAbs, Gaussian
 from astromodels import Parameter
 
 from cosipy.response.FullDetectorResponse import FullDetectorResponse
@@ -12,14 +11,13 @@ from scoords import SpacecraftFrame, Attitude
 
 from mhealpy import HealpixMap
 
-from cosipy.response import PointSourceResponse
+from cosipy.response import PointSourceResponse, DetectorResponse
 from histpy import Histogram
 import h5py as h5
 from histpy import Axis, Axes
 import sys
 
 import astropy.units as u
-from astropy.units import Quantity
 import astropy.coordinates as coords
 
 from sparse import COO
@@ -27,7 +25,6 @@ from sparse import COO
 import numpy as np
 
 from scipy.special import factorial
-from scipy import integrate
 
 import collections
 
@@ -114,29 +111,14 @@ class COSILike(PluginPrototype):
         # Option to use precomputed point source response.
         # Note: this still needs to be implemented in a 
         # consistent way for point srcs and extended srcs. 
-        # Here we will get the axes information. 
         self.precomputed_psr_file = precomputed_psr_file
-#        if self.precomputed_psr_file != None:
-#            with h5.File(self.precomputed_psr_file) as f:
-#
-#                axes_group = f['hist/axes']
-#                axes = []
-#                for axis in axes_group.values():
-#
-#                    # Get class. Backwards compatible with version
-#                    # with only Axis
-#                    axis_cls = Axis
-#
-#                    if '__class__' in axis.attrs:
-#                        class_module, class_name = axis.attrs['__class__']
-#                        axis_cls = getattr(sys.modules[class_module], class_name)
-#
-#                    axes += [axis_cls._open(axis)]
-#
-#            self.psr_axes = Axes(axes)
-        
-        print("...loading the pre-computed image response")
-        self.image_response = Histogram.open(self.precomputed_psr_file)
+        if self.precomputed_psr_file != None:
+
+            print("... loading the pre-computed image response ...")
+            self.image_response = DetectorResponse.open(self.precomputed_psr_file)
+            # in the near future, we will implement ExtendedSourceResponse class, which should be used here.
+            # probably, it is better to move this loading part outside of this class. Then, we don't have to load the response everytime we start the fitting.
+            print("--> done")
         
     def set_model(self, model):
         
@@ -161,44 +143,21 @@ class COSILike(PluginPrototype):
             # Set spectrum:
             # Note: the spectral parameters are updated internally by 3ML
             # during the likelihood scan. 
-            spectrum = source.spectrum.main.shape
 
-            # just for Gaussian
-            spectrum_unit = spectrum.F.unit / spectrum.sigma.unit
+            model_map = ModelMap(nside = self.image_response.axes['NuLambda'].nside, 
+                                energy_edges = self.image_response.axes['Ei'].edges,
+                                coordsys = 'galactic',
+                                label_image = 'NuLambda', # I think the label should be something like 'lb' to distiguish the photon direction in the local/galactic coordinates 
+                                label_energy = 'Ei')
 
-            eaxis = self.image_response.axes['Ei']
-
-            flux = Quantity([integrate.quad(spectrum, lo_lim/lo_lim.unit, hi_lim/hi_lim.unit)[0] * spectrum_unit * lo_lim.unit for lo_lim,hi_lim in zip(eaxis.lower_bounds, eaxis.upper_bounds)])
-
-            modelmap = ModelMap(nside = self.image_response.axes['NuLambda'].nside, energy_edges = eaxis.edges)
-            modelmap.axes[0].label = 'NuLambda'
-           
-            npix = modelmap.axes[0].npix 
-            coords = modelmap.axes[0].pix2skycoord(np.arange(npix))
-            normalized_map = source.spatial_shape(coords.l.deg, coords.b.deg) / u.sr
-
-            modelmap[:] = np.tensordot(normalized_map, flux, axes = 0) 
+            model_map.set_values_from_extendedmodel(source)
 
             # Get expectation using precomputed psr in Galactic coordinates:
-            total_expectation = Histogram(edges = self.image_response.axes[2:])
-
-            total_expectation += np.tensordot(modelmap.contents, self.image_response.contents, axes = ([0,1], [0,1])) * 4 * np.pi / npix * u.sr
-
-#            with h5.File(self.precomputed_psr_file) as f:
-# 
-#                # sum over sky pixels: 
-#                for i in range(len(source.grid)):
-#
-#                    pix = source.grid[i]
-#                    weight = source.skymap[pix]
-#
-#                    if weight == 0:
-#                        continue
-#
-#                    psr = PointSourceResponse(self.psr_axes[1:], f['hist/contents'][pix+1], unit = f['hist'].attrs['unit'])
-#                    pix_expectation = psr.get_expectation(spectrum).project(['Em', 'Phi', 'PsiChi'])
-#
-#                    total_expectation += pix_expectation*(weight*4*np.pi/source.skymap.npix)
+            total_expectation = Histogram(edges = self.image_response.axes[2:],
+                                          contents = np.tensordot(model_map.contents, self.image_response.contents, axes = ([0,1], [0,1])) * model_map.axes['NuLambda'].pixarea())
+            # ['NuLambda', 'Ei'] x ['NuLambda', 'Ei', 'Em', 'Phi', 'PsiChi'] => 'Em', 'Phi', 'PsiChi']
+            # this part should be modified with the future ExtendedSourceResponse class like
+            # total_expectation = self.image_response.get_expectation(model_map)
 
             # Need to check if self._signal type is dense (i.e. 'Quantity') or sparse (i.e. 'COO').
             if type(total_expectation.contents) == u.quantity.Quantity:

--- a/cosipy/threeml/COSILike.py
+++ b/cosipy/threeml/COSILike.py
@@ -116,8 +116,8 @@ class COSILike(PluginPrototype):
 
             print("... loading the pre-computed image response ...")
             self.image_response = DetectorResponse.open(self.precomputed_psr_file)
-            # in the near future, we will implement ExtendedSourceResponse class, which should be used here.
-            # probably, it is better to move this loading part outside of this class. Then, we don't have to load the response everytime we start the fitting.
+            # in the near future, we will implement ExtendedSourceResponse class, which should be used here (HY).
+            # probably, it is better to move this loading part outside of this class. Then, we don't have to load the response everytime we start the fitting (HY).
             print("--> done")
         
     def set_model(self, model):
@@ -158,6 +158,8 @@ class COSILike(PluginPrototype):
             # ['NuLambda', 'Ei'] x ['NuLambda', 'Ei', 'Em', 'Phi', 'PsiChi'] => 'Em', 'Phi', 'PsiChi']
             # this part should be modified with the future ExtendedSourceResponse class like
             # total_expectation = self.image_response.get_expectation(model_map)
+            # or 
+            # total_expectation = self.image_response.get_expectation_from_astromodel(source) (HY)
 
             # Need to check if self._signal type is dense (i.e. 'Quantity') or sparse (i.e. 'COO').
             if type(total_expectation.contents) == u.quantity.Quantity:
@@ -282,7 +284,7 @@ class COSILike(PluginPrototype):
 
         expectation += 1e-12 
         # to avoid infinite likelihood
-        # This 1e-12 should be defined as a parameter in the near future
+        # This 1e-12 should be defined as a parameter in the near future (HY)
         
         # Convert data into an arrary:
         data = self._data.contents

--- a/cosipy/threeml/COSILike.py
+++ b/cosipy/threeml/COSILike.py
@@ -174,49 +174,62 @@ class COSILike(PluginPrototype):
                 self._signal += total_expectation
             self.src_counter += 1
 
-        # Get expectation for point sources:
-        for name,source in point_sources.items():
+        # Initialization
+        # probably it is better that this part be outside of COSILike (HY).
+        if self._psr is None or len(point_sources) != len(self._psr):
 
-            if self._source is None:
-                self._source = copy.deepcopy(source) # to avoid same memory issue
-                     
-            # Compute point source response for source position
-            # See also the Detector Response and Source Injector tutorials
-            if self._psr is None:
-            
-                coord = self._source.position.sky_coord
-                
-                if self._coordsys == 'spacecraftframe':
-                    dwell_time_map = self._get_dwell_time_map(coord)
-                    self._psr = self._dr.get_point_source_response(exposure_map=dwell_time_map)
-                elif self._coordsys == 'galactic':
-                    scatt_map = self._get_scatt_map()
-                    self._psr = self._dr.get_point_source_response(coord=coord, scatt_map=scatt_map)
-                else:
-                    raise RuntimeError("Unknown coordinate system")
-                
-            elif (source.position.sky_coord != self._source.position.sky_coord):
-                
+            print("... Calculating point source responses ...")
+
+            self._psr = {}
+            self._source_location = {} # Shoule the poition information be in the point source response? (HY)
+
+            for name, source in point_sources.items():
                 coord = source.position.sky_coord
                 
+                self._source_location[name] = copy.deepcopy(coord) # to avoid same memory issue
+
                 if self._coordsys == 'spacecraftframe':
                     dwell_time_map = self._get_dwell_time_map(coord)
-                    self._psr = self._dr.get_point_source_response(exposure_map=dwell_time_map)
+                    self._psr[name] = self._dr.get_point_source_response(exposure_map=dwell_time_map)
                 elif self._coordsys == 'galactic':
                     scatt_map = self._get_scatt_map()
-                    self._psr = self._dr.get_point_source_response(coord=coord, scatt_map=scatt_map)
+                    self._psr[name] = self._dr.get_point_source_response(coord=coord, scatt_map=scatt_map)
                 else:
                     raise RuntimeError("Unknown coordinate system")
+
+                print(f"--> done (source name : {name})")
+
+            print(f"--> all done")
+        
+        # check if the source location is updated or not
+        for name, source in point_sources.items():
+
+            if source.position.sky_coord != self._source_location[name]:
+                print(f"... Re-calculating the point source response of {name} ...")
+                coord = source.position.sky_coord
+
+                self._source_location[name] = copy.deepcopy(coord) # to avoid same memory issue
                 
-            # Caching source to self._source after position judgment
-            if self._source is not None:
-                self._source = copy.deepcopy(source)
+                if self._coordsys == 'spacecraftframe':
+                    dwell_time_map = self._get_dwell_time_map(coord)
+                    self._psr[name] = self._dr.get_point_source_response(exposure_map=dwell_time_map)
+                elif self._coordsys == 'galactic':
+                    scatt_map = self._get_scatt_map()
+                    self._psr[name] = self._dr.get_point_source_response(coord=coord, scatt_map=scatt_map)
+                else:
+                    raise RuntimeError("Unknown coordinate system")
+
+                print(f"--> done (source name : {name})")
+
+        # Get expectation for point sources:
+        for name,source in point_sources.items():
 
             # Convolve with spectrum
             # See also the Detector Response and Source Injector tutorials
             spectrum = source.spectrum.main.shape
                 
-            total_expectation = self._psr.get_expectation(spectrum).project(['Em', 'Phi', 'PsiChi'])
+            total_expectation = self._psr[name].get_expectation(spectrum).project(['Em', 'Phi', 'PsiChi'])
+            # should it be like self._psr[name].get_expectation(spectrum) (without 'project')? (HY)
          
             # Need to check if self._signal type is dense (i.e. 'Quantity') or sparse (i.e. 'COO').
             if type(total_expectation.contents) == u.quantity.Quantity:
@@ -255,11 +268,21 @@ class COSILike(PluginPrototype):
         
         # Compute expectation including free background parameter:
         if self._fit_nuisance_params: 
-            expectation = self._signal + self._nuisance_parameters[self._bkg_par.name].value * self._bkg.contents.todense()
+            if type(self._bkg.contents) == COO:
+                expectation = self._signal + self._nuisance_parameters[self._bkg_par.name].value * self._bkg.contents.todense()
+            else:
+                expectation = self._signal + self._nuisance_parameters[self._bkg_par.name].value * self._bkg.contents
         
         # Compute expectation without background parameter:
         else: 
-            expectation = self._signal + self._bkg.contents.todense()
+            if type(self._bkg.contents) == COO:
+                expectation = self._signal + self._bkg.contents.todense()
+            else:
+                expectation = self._signal + self._bkg.contents
+
+        expectation += 1e-12 
+        # to avoid infinite likelihood
+        # This 1e-12 should be defined as a parameter in the near future
         
         # Convert data into an arrary:
         data = self._data.contents
@@ -269,6 +292,7 @@ class COSILike(PluginPrototype):
         
         # Need to mask zero-values pixels if obtaining infinite likelihood.
         # Note: the mask function gives errors sometimes. This is a bug that needs to be fixed. 
+        # This part can be removed because the minimum value in expectation is now 1e-12 (HY)
         if log_like == -np.inf:
             logger.warning(f"There are bins in which the total expected counts = 0 but data != 0, making log-likelihood = -inf. "
                            f"Masking these bins.")


### PR DESCRIPTION
I've modified the extended model fitting part in COSILike.py. The main changes are:

- The pre-computed image response is loaded onto a CPU memory at once
- The astromodel.ExtendedModel is converted into ModelMap, which is a 2D Histogram.
-- ModelMap is originally implemented for the image deconvolution. So it is now in cosipy.image_deconvolution. In the future, it can be moved to a different directory.
-- In this commit, I implemented the function `set_values_from_extendedmodel` in ModelMap, to calculate the datacube from a given extended model.
- Then, the expected counts are calculated as a simple matrix calculation as `np.tensordot(model_map.contents, self.image_response.contents, axes = ([0,1], [0,1])) * model_map.axes['NuLambda'].pixarea()`
-- using `np.tensordot` is faster than `image_response.expand_dims(...)` since reducing intermediate response size.
-- this part should be implemented in the future `ExtendedSourceResponse` class.